### PR TITLE
Fix broken link to `site/about.html`

### DIFF
--- a/site/guidelines-reviewers.qmd
+++ b/site/guidelines-reviewers.qmd
@@ -44,7 +44,7 @@ In order to help you in performing your review we provide a list of the main que
 
 1. **Is the paper within the scope of Computo?**
 
-    See [Aims and Scope](/about) of Computo.
+    See [Aims and Scope](./about.qmd) of Computo.
 
 2. **Is the paper clearly written?**
 


### PR DESCRIPTION
The link to the about page is broken and points at `/about` at root, but it lives at `/site/about.html`. Fix it by adding a relative link pointing to the `.qmd` file (which quarto converts automatically to a `.html` link extension at render time.

I've verified that this fixes the issue locally.