### PR TITLE
Fix broken repo URL in blog post

### DIFF
--- a/blog/2025-07-31-reproduce-paper/index.qmd
+++ b/blog/2025-07-31-reproduce-paper/index.qmd
@@ -11,7 +11,7 @@ format:
 page-layout: article
 ---
 
-Our publication workflow makes it very easy for anyone to reproduce a given paper. Consider for instance the paper <https://doi.org/10.57750/sfxn-1t05> associated with the Github repository [published-202412-giorgi-efficient][https://github.com/computorg/published-202412-giorgi-efficient]. You first need to clone the repository. Then you need to install Quarto and the Computo Quarto extension in the `published-202412-giorgi-efficient` folder that the cloning step made. Finally, you can render the document. In summary, you do that with the following commands:
+Our publication workflow makes it very easy for anyone to reproduce a given paper. Consider for instance the paper <https://doi.org/10.57750/sfxn-1t05> associated with the Github repository [published-202412-giorgi-efficient](https://github.com/computorg/published-202412-giorgi-efficient). You first need to clone the repository. Then you need to install Quarto and the Computo Quarto extension in the `published-202412-giorgi-efficient` folder that the cloning step made. Finally, you can render the document. In summary, you do that with the following commands:
 
 ```bash
 git clone https://github.com/computorg/published-202412-giorgi-efficient.git


### PR DESCRIPTION
The blog post has a `[...][...]` syntax for a link, but it should be `[...](...)`, I think. Currently it doesn't render and Quarto/Pandoc presents this as raw text (because it has no valid anchor for the reference).